### PR TITLE
Fix bug where header.name is not set

### DIFF
--- a/welly/header.py
+++ b/welly/header.py
@@ -22,6 +22,8 @@ class Header(object):
         """
         Generic initializer for now.
         """
+        setattr(self, 'name', 'unknown')
+        
         for k, v in params.items():
             if k and v:
                 setattr(self, k, v)


### PR DESCRIPTION
If the LAS file has no entry for ~Well WELL. then header.name is never set and w.plot() fails with an error.

Example LAS file: https://gist.githubusercontent.com/kinverarity1/2d2ae81f41b0e8c9e0022e0fc990f832/raw/0a387ac27b0b45725e9ba6cfe156398f70e2a4fe/example.las

``` python
>>> import welly
>>> w = welly.Well.from_las(r"c:\users\kinverarity\Documents\scratch2016\welly_bug_depth\example.las")
>>> w._repr_html_()
'<table><tr><th style="text-align:center;" colspan="2"><br><small>unknown</small></th></tr><tr><td><strong>crs</strong></td><td>CRS({})</td></tr><tr><td><strong>td</strong></td><td>None</td></tr><tr><td><strong>data</strong></td><td>Cali, Dens, Gamm, Late, Neut, PntR, Spon</td></tr></table>'
>>> w.plot()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files (x86)\Misc\kentcode\welly\welly\well.py", line 427, in plot
    fig.suptitle(self.header.name, size=16, zorder=100,
AttributeError: 'Header' object has no attribute 'name'
>>>
```

Fixed it by setting `header.name = 'unknown'` in the `Header.__init__` method before the passed arguments are set.
