### PR TITLE
Support for Python 2.7

### DIFF
--- a/welly/crs.py
+++ b/welly/crs.py
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 import collections
 
 
-class CRS(collections.abc.MutableMapping):
+class CRS(collections.MutableMapping):
 
     def __init__(self, *args, **kwargs):
         '''

--- a/welly/curve.py
+++ b/welly/curve.py
@@ -5,6 +5,8 @@ Defines log curves.
 :copyright: 2016 Agile Geoscience
 :license: Apache 2.0
 """
+from __future__ import division
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl

--- a/welly/project.py
+++ b/welly/project.py
@@ -5,6 +5,8 @@ Defines a multi-well 'project'.
 :copyright: 2016 Agile Geoscience
 :license: Apache 2.0
 """
+from __future__ import print_function
+
 import glob
 from collections import Counter
 import re

--- a/welly/utils.py
+++ b/welly/utils.py
@@ -5,6 +5,8 @@ Utility functions for welly.
 :copyright: 2016 Agile Geoscience
 :license: Apache 2.0
 """
+from __future__ import division
+
 import re
 import glob
 

--- a/welly/well.py
+++ b/welly/well.py
@@ -5,6 +5,8 @@ Defines wells.
 :copyright: 2016 Agile Geoscience
 :license: Apache 2.0
 """
+from __future__ import division
+
 import re
 import datetime
 


### PR DESCRIPTION
This PR takes welly from failing all 27 tests for python 2.7 to failing 1/27 (vs 0/27 for python 3.6).

The failing test relates to striplog, not welly. I'll raise an issue for that over there in a moment.