### PR TITLE
fixes issue 90: unwanted conversion of depth from 'ft' to 'm'

### DIFF
--- a/welly/well.py
+++ b/welly/well.py
@@ -152,11 +152,11 @@ class Well(object):
         if req:
             reqs = utils.flatten_list([v for k, v in alias.items() if k in req])
 
-        # Using lasio's idea of depth in metres:
-        if l.depth_m[0] < l.depth_m[1]:
-            curve_params['depth'] = l.depth_m
+        # Using lasio's index property for depth values:
+        if l.index[0] < l.index[1]:
+            curve_params['depth'] = l.index
         else:
-            curve_params['depth'] = np.flipud(l.depth_m)
+            curve_params['depth'] = np.flipud(l.index)
 
         # Make the curve dictionary.
         depth_curves = ['DEPT', 'TIME']


### PR DESCRIPTION
[Issue 90](https://github.com/agile-geoscience/welly/issues/90)

When loading *.las files with the depth units in ft, the depth track was converted to m.

It looks like this is because in the `well.from_lasio()` method sets the `curve_params['depth']` from the laiso property `depth_m` rather than `index`. It seems to me that the `from_lasio()` method should read in whatever units are in the .las file rather than force any unit conversion.

The lasio property [index](https://github.com/kinverarity1/lasio/blob/5187f4fd1f05baaea1117764729b3d9a1d77aa7a/lasio/las.py#L642) returns the first column of the las file.