### PR TITLE
Pass kwargs from Well.to_las to lasio.LASFile.write

### DIFF
--- a/welly/well.py
+++ b/welly/well.py
@@ -374,7 +374,7 @@ class Well(object):
 
         return l
 
-    def to_las(self, fname, keys=None, basis=None):
+    def to_las(self, fname, keys=None, basis=None, **kwargs):
         """
         Writes the current well instance as a LAS file. Essentially just wraps
         ``to_lasio()``, but is more convenient for most purposes.
@@ -388,11 +388,13 @@ class Well(object):
                 include, if not all of them. You can have nested lists, such
                 as you might use for ``tracks`` in ``well.plot()``.
 
+        Other keyword args are passed to lasio.LASFile.write.
+
         Returns:
             None. Writes the file as a side-effect.
         """
         with open(fname, 'w') as f:
-            self.to_lasio(keys=keys, basis=basis).write(f)
+            self.to_lasio(keys=keys, basis=basis).write(f, **kwargs)
 
         return
 


### PR DESCRIPTION
This allows users to control the output of LAS files, by passing any kwargs from ``Well.to_las`` to ``lasio.LASFile.write``.

At the moment the main one that might be needed is ``fmt``, which controls the numeric formatting of values in the data sections: https://github.com/kinverarity1/lasio/blob/41a379ed1e0113bfaf4053354ac2f21480fee63a/lasio/writer.py#L36-L37

Others will be added in the future (e.g. kinverarity1/lasio#266).

Prompted by #107 which is not directly solved by this PR, but it is relevant.