### PR TITLE
Fix for #131: allow pathlib.Path objects in Well.from_las

### DIFF
--- a/tests/test_well.py
+++ b/tests/test_well.py
@@ -38,6 +38,12 @@ def test_well():
     assert len(well.data['HCAL']) == len(well.data['RHOB'])
 
 
+def test_well_pathlib():
+    from pathlib import Path
+
+    well = Well.from_las(Path(FNAME))
+
+
 def test_html_repr():
     well = Well.from_las(FNAME)
     html = well._repr_html_()

--- a/welly/utils.py
+++ b/welly/utils.py
@@ -573,3 +573,24 @@ def find_file(pattern, path):
             if re.search(pattern, f.read()):
                 return fname
     return
+
+
+def to_filename(path):
+    """
+    Convert string/pathlib.Path to string.
+
+    Args:
+        path (str/pathlib.Path): filename
+
+    Returns:
+        str: filename
+    """
+    try:
+        from pathlib import Path
+    except ImportError:
+        return file_ref
+
+    if isinstance(path, Path):
+        return path.absolute().__str__()
+    else:
+        return path

--- a/welly/well.py
+++ b/welly/well.py
@@ -288,6 +288,9 @@ class Well(object):
         Returns:
             well. The well object.
         """
+
+        fname = utils.to_filename(fname)
+
         if printfname:
             print(fname)
 


### PR DESCRIPTION
This PR fixes #131. It contains three changes:

- A function `utils.to_filename` which accepts either a string or `pathlib.Path` object and returns a string. Thanks @dcslagel for the [original code](https://github.com/kinverarity1/lasio/pull/294).
- Changes to `Well.from_las` so that the `fname` argument is converted to a string before anything else happens
- A new test in `test_well.py` to check that a well can be created using a `pathlib.Path` object. This test fails for the current develop branch, and passes with this PR.