### PR TITLE
Fix AssertionError in test_project::test_project

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -19,7 +19,7 @@ def test_project():
 
     project += project
 
-    assert project.uwis[0] == 1
+    assert project.uwis[0] == '1'
 
     s = "<table>"
     s += "<tr><th>Index</th><th>UWI</th><th>Data</th><th>Curves</th></tr>"


### PR DESCRIPTION
This pull-request resolves the following error in the current test suite:
`FAILED tests/test_project.py::test_project - AssertionError: assert '1' == 1`
This issue exists on both the master and the develop branches.

It is evaluating `assert project.uwis[0]` which stores a str object.


coverage report after this change:
```
Name                      Stmts   Miss  Cover
---------------------------------------------
welly/__init__.py            16      2    88%
welly/_version.py             2      0   100%
welly/canstrat.py           102     23    77%
welly/canstrat_codes.py      23      0   100%
welly/crs.py                 49      7    86%
welly/curve.py              382    114    70%
welly/defaults.py             2      0   100%
welly/fields.py               2      0   100%
welly/header.py              30      8    73%
welly/location.py           153     58    62%
welly/project.py            353    198    44%
welly/quality.py             81     31    62%
welly/scales.py              56     22    61%
welly/synthetic.py           47      9    81%
welly/tools.py                7      1    86%
welly/utils.py              200     44    78%
welly/well.py               523    203    61%
---------------------------------------------
TOTAL                      2028    720    64%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC