### PR TITLE
Allow trajectories to have less than 3 points

### DIFF
--- a/welly/location.py
+++ b/welly/location.py
@@ -305,8 +305,13 @@ class Location(object):
         if datum is not None:
             pos += datum
 
+        if pos.shape[0] < 3:
+            k = pos.shape[0] - 1
+        else:
+            k = 3
+
         # Compute the spline and return as an array instead of as vectors.
-        knees, _ = splprep(pos.T, k=3, **kwargs)
+        knees, _ = splprep(pos.T, k=k, **kwargs)
         spline = splev(np.linspace(0, 1, points), knees)
         return np.array(spline).T
 

--- a/welly/location.py
+++ b/welly/location.py
@@ -305,7 +305,7 @@ class Location(object):
         if datum is not None:
             pos += datum
 
-        if pos.shape[0] < 3:
+        if pos.shape[0] <= 3:
             k = pos.shape[0] - 1
         else:
             k = 3

--- a/welly/well.py
+++ b/welly/well.py
@@ -51,6 +51,7 @@ class Well(object):
         """
         Generic initializer for now.
         """
+
         if getattr(self, 'data', None) is None:
             self.data = {}
 
@@ -63,6 +64,8 @@ class Well(object):
         for k, v in params.items():
             if k and (v is not None):
                 setattr(self, k, v)
+
+        self.location = None
 
     def __eq__(self, other):
         if (not self.uwi) or (not other.uwi):


### PR DESCRIPTION
- Due to the degree of interpolation used for the trajectory, if the well has less than 4 points. It breaks
- Also initialize Well.location empty. It gave me problems at some point
