### PR TITLE
Wellpathpy not found with `pip install -e .`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ REQUIREMENTS = ['numpy',
                 'lasio',
                 'striplog',
                 'tqdm',
+                'wellpathpy'
                 ]
 
 TEST_REQUIREMENTS = ['pytest',


### PR DESCRIPTION
Cloning the repo and installing from source fails with a `ModuleNotFound` error:

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-08d490c09a2e> in <module>
      1 import lasio
----> 2 import welly

c:\devapps\kinverarity\projects\welly\welly\__init__.py in <module>
      4 ==================
      5 """
----> 6 from .project import Project
      7 from .well import Well
      8 from .header import Header

c:\devapps\kinverarity\projects\welly\welly\project.py in <module>
     16 from tqdm import tqdm
     17 
---> 18 from .well import Well, WellError
     19 from . import utils
     20 from .utils import deprecated

c:\devapps\kinverarity\projects\welly\welly\well.py in <module>
     23 from .curve import Curve
     24 from .header import Header
---> 25 from .location import Location
     26 from .synthetic import Synthetic
     27 from .canstrat import well_to_card_1

c:\devapps\kinverarity\projects\welly\welly\location.py in <module>
     19 from .fields import dev_fields
     20 from .crs import CRS
---> 21 from .tools import compute_position_log
     22 
     23 

c:\devapps\kinverarity\projects\welly\welly\tools.py in <module>
      6 """
      7 import numpy as np
----> 8 import wellpathpy as wp
      9 import warnings
     10 

ModuleNotFoundError: No module named 'wellpathpy'
```

This PR fixes the issue by adding `wellpathpy` to `install_requires=` in `setup.py`.