### PR TITLE
Patrick/fixes for pandas issues

### DIFF
--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -18,8 +18,7 @@ from welly import Synthetic
 from welly import Location
 
 params = {'tolerance': 20,
-          'savefig_kwargs': {'dpi': 100},
-          }
+          'savefig_kwargs': {'dpi': 100}}
 
 FNAME = 'tests/assets/P-129_out.LAS'
 FNAME_PROJECT = 'tests/assets/P-129_out-with*.LAS'
@@ -113,7 +112,6 @@ def test_well_plot(well):
     """
     Tests mpl image of well.
     """
-    plot = well.plot(tracks=['MD', 'GR', 'DT'],
-                    extents='curves')
+    plot = well.plot(tracks=['MD', 'GR', 'DT'], extents='curves')
 
     return plot.get_figure()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -46,18 +46,16 @@ def test_project():
 
 def test_data_as_matrix():
     """
-    Test currently not working
+    Test creating test and train matrices from wells in a project
     """
-    # alias = {'Sonic': ['DT', 'foo']}
-    # project = Project.from_las('tests/assets/*.las')
-    # X_train, y_train = project.data_as_matrix(X_keys=['DEPT', 'HCAL', 'Sonic'],
-    #                                           y_key='CALI',
-    #                                           alias=alias,
-    #                                           window_length=1,
-    #                                           remove_zeros=True,
-    #                                           )
-    # # Test needs repair
-    # assert X_train.shape[0] == y_train.size
+    alias = {'Sonic': ['DT', 'foo']}
+    project = Project.from_las('tests/assets/*.las')
+    X_train, y_train = project.data_as_matrix(X_keys=['DEPT', 'HCAL', 'Sonic'],
+                                              y_key='CALI',
+                                              alias=alias,
+                                              window_length=1,
+                                              remove_zeros=True)
+    assert X_train.shape[0] == y_train.size
 
 
 def test_df():

--- a/tests/test_well.py
+++ b/tests/test_well.py
@@ -94,6 +94,13 @@ def test_df(well):
     assert df.iloc[10, 2] - 3.586400032 < 0.001
     assert df.shape == (12718, 24)
 
+    # test with keyword arguments
+    alias = {'Gamma': ['GR', 'GRC', 'NGT'], 'Caliper': ['HCAL', 'CALI']}
+    keys = ['Caliper', 'Gamma', 'DT']
+    df = well.df(keys=keys, alias=alias, uwi=True)
+    assert df.iloc[10, 1] - 46.69865036 < 0.001
+    assert df.shape == (12718, 3)
+
 
 def test_read_df(df):
     """

--- a/welly/curve.py
+++ b/welly/curve.py
@@ -313,9 +313,12 @@ class Curve(object):
     @dtypes.setter
     def dtypes(self, dtypes):
         """
-        Set the data types of the columns of the pd.DataFrame (str)
+        Set the data types of the columns of the pd.DataFrame
+
+        Args:
+            dtypes (data type, or dict of column name: data type): types to convert to
         """
-        return setattr(self, 'df',  self.df.astype(dtypes))
+        setattr(self, 'df',  self.df.astype(dtypes))
 
     @property
     def index_name(self):
@@ -401,14 +404,14 @@ class Curve(object):
         Returns the minimum of the pd.DataFrame values of the columns in the curve
         in a pd.Series
         """
-        return self.df.min()
+        return self.df.min(axis=axis, **kwargs)
 
     def max(self, axis=None, **kwargs):
         """
         Returns the maximum of the pd.DataFrame values of the columns in the curve
         in a pd.Series
         """
-        return self.df.max()
+        return self.df.max(axis=axis, **kwargs)
 
     def describe(self):
         """
@@ -495,7 +498,6 @@ class Curve(object):
             return result, rolled
         else:
             return result
-
 
     def despike(self, window_length=33, samples=True, z=2):
         """

--- a/welly/curve.py
+++ b/welly/curve.py
@@ -788,12 +788,13 @@ class Curve(object):
         Returns:
             Curve. The current instance in the new basis.
         """
-        # category data type or a string in data defaults to 'nearest'
-        if self.df.dtypes[0] == 'category' or self.df.applymap(type).eq(str).any()[0]:
-            interp_kind = 'nearest'
-        else:
-            # otherwise apply linear interpolation
-            interp_kind = 'linear'
+        if not interp_kind:
+            # category data type or any string in data defaults to 'nearest'
+            if self.df.dtypes[0] == 'category' or self.df.applymap(type).eq(str).any()[0]:
+                interp_kind = 'nearest'
+            else:
+                # otherwise apply linear interpolation by default
+                interp_kind = 'linear'
 
         new_curve = copy.deepcopy(self)
 
@@ -822,9 +823,7 @@ class Curve(object):
                               bounds_error=False,
                               fill_value=undefined)
             # create new df with interpolated data
-            new_df = pd.DataFrame(interp(basis),
-                                  index=basis,
-                                  columns=self.df.columns)
+            new_df = pd.DataFrame(interp(basis), index=basis, columns=self.df.columns)
             # create and set new df attribute on curve
             setattr(new_curve, 'df', new_df)
             # propagate old df attributes to new df curve attribute

--- a/welly/well.py
+++ b/welly/well.py
@@ -595,7 +595,10 @@ class Well(object):
 
         if uwi:
             df['UWI'] = self.uwi
+            # add UWI as index as part of a MultiIndex
             df.set_index(['UWI'], append=True, inplace=True)
+            # swap MultiIndex levels
+            df = df.swaplevel()
 
         for column in df.columns:
             if is_object_dtype(df[column].dtype):

--- a/welly/well.py
+++ b/welly/well.py
@@ -726,23 +726,42 @@ class Well(object):
 
         starts, stops, steps = [], [], []
         for k in keys:
-            d = self.get_curve(k, alias=alias)
-            if keys and (d is None):
+            curve = self.get_curve(k, alias=alias)
+            if keys and (curve is None):
                 continue
             try:
-                starts.append(d.start)
-                stops.append(d.stop)
-                steps.append(d.step)
+                starts.append(curve.start)
+                stops.append(curve.stop)
+                steps.append(curve.step)
             except Exception as e:
                 pass
         if starts and stops and steps:
-            step = step or min(steps)
-            return np.arange(min(starts), max(stops) + 1e-9, step)
+            if 0 in steps:
+                # remove all unequally sampled curves (step = 0) from list
+                steps = list(filter((0).__ne__, steps))
+            if step:
+                step = step
+            elif steps:
+                step = min(steps)
+            else:
+                step = None
+            if min(starts) > min(stops):
+                # create basis array and flip to descending
+                return np.flipud(np.arange(max(stops), min(starts) + 1e-9, step))
+            else:
+                # create basis array
+                return np.arange(min(starts), max(stops) + 1e-9, step)
+
         else:
             return None
 
-    def unify_basis(self, keys=None, alias=None, basis=None, start=None,
-                    stop=None, step=None):
+    def unify_basis(self,
+                    keys=None,
+                    alias=None,
+                    basis=None,
+                    start=None,
+                    stop=None,
+                    step=None):
         """
         Give every Curve in the well, or everything in the list of keys, the
         same basis. If you don't provide a basis, welly will try to get one


### PR DESCRIPTION
Some fixes for the outstanding issues for the `0.5.0` release.

Fixes for open issues:
- #183 Fix for `Well.df()` multtiindex order. Now UWI is first, depth/time index second. 
- #181 Fix for `Project.data_to_matrix()`, needed to stop overwriting `y_key` variable to `None`. Added docstring. Not sure how useful and usable this method currently is.

Other related and unrelated fixes:
- Fix for `survey_basis()` with unequal basis and descending basis. We're currently allowing for descending curve index/basis. This was not accounted for in this method.
- Small fixes for curve type casting and properties.
- Small formatting changes.