### PR TITLE
fix plot_2d color fill

### DIFF
--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -10,7 +10,6 @@ welly/run_tests.py
 https://pypi.python.org/pypi/pytest-mpl/0.3
 """
 import pytest
-import matplotlib.pyplot as plt
 
 from welly import Well
 from welly import Project
@@ -18,8 +17,7 @@ from welly import Synthetic
 from welly import Location
 
 params = {'tolerance': 20,
-          'savefig_kwargs': {'dpi': 100},
-          }
+          'savefig_kwargs': {'dpi': 100}}
 
 FNAME = 'tests/assets/P-129_out.LAS'
 FNAME_PROJECT = 'tests/assets/P-129_out-with*.LAS'
@@ -76,7 +74,16 @@ def test_curve_2d_plot(well):
     """
     Tests mpl image of curve as VD display.
     """
-    fig = well.data['GR'].plot_2d().get_figure()
+    curve = well.data['GR']
+
+    # plot 2D curve
+    curve.plot_2d()
+
+    # subtract curve values from 200
+    curve2 = 200-curve
+
+    # plot a curve with clipped colored mask
+    fig = curve2.plot_2d(cmap='viridis', curve=True, lw=-.5, edgecolor='k').get_figure()
 
     return fig
 
@@ -87,8 +94,8 @@ def test_synthetic_plot():
     Tests mpl image of synthetic.
     """
     data = [4, 2, 0, -4, -2, 1, 3, 6, 3, 1, -2, -5, -1, 0]
-    params = {'dt': 0.004}
-    s = Synthetic(data, params=params)
+    test_params = {'dt': 0.004}
+    s = Synthetic(data, params=test_params)
 
     fig = s.plot().get_figure()
 

--- a/welly/curve.py
+++ b/welly/curve.py
@@ -77,7 +77,7 @@ class Curve(object):
                  run=None,
                  service_company=None,
                  units=None,
-                 family=None):
+                 log_type=None):
 
         if isinstance(mnemonic, str):
             mnemonic = [mnemonic]
@@ -98,7 +98,7 @@ class Curve(object):
         self.code = code
         self.description = description
         self.units = units
-        self.family = family
+        self.log_type = log_type
         # set parameters related to well
         self.api = api
         self.date = date

--- a/welly/plot.py
+++ b/welly/plot.py
@@ -376,11 +376,13 @@ def plot_2d_curve(curve,
         raise NotImplementedError("Can only handle up to 3 dimensions.")
 
     # At this point, a is either a 2D array, or a 2D (rgb) array.
-    extent = [0, width or default, curve.stop, curve.start]
+    extent = [min(curve_data) or 0, max(curve_data) or default, curve.stop, curve.start]
     im = ax.imshow(a, cmap=cmap, extent=extent, aspect='auto')
 
     if plot_curve:
-        paths = ax.fill_betweenx(curve.basis, curve_data, np.nanmin(curve_data),
+        paths = ax.fill_betweenx(y=curve.basis,
+                                 x1=curve_data,
+                                 x2=np.nanmin(curve_data),
                                  facecolor='none',
                                  **kwargs)
 
@@ -388,8 +390,9 @@ def plot_2d_curve(curve,
         patch = PathPatch(paths._paths[0], visible=False)
         ax.add_artist(patch)
         im.set_clip_path(patch)
-
-    ax.set_xticks([])
+    else:
+        # if not plotting a curve, the x-axis is dimensionless
+        ax.set_xticks([])
 
     # Rely on interval order.
     lower, upper = curve.stop, curve.start


### PR DESCRIPTION
**pytest for python versions 3.8, 3.9 3.10 are failing, fixes for this are in #193**

This PR addresses issue #182 

For curves with negative values the `plot_2d(plot_curve=True)` was not coming up correctly because the extent of then `imshow` ran from 0 to max(curve_data). Now the extent is:

`extent = [min(curve_data) or 0, max(curve_data) or default, curve.stop, curve.start]`

This allows for complete color fill of the curve.

Also enabled axis tick labels when plotting the curve because it has a dimension, unlike the `plot_curve=False` plot.

Previous output before changes:

![image](https://user-images.githubusercontent.com/59961184/148904843-7f26fdab-b04a-45ae-9280-10f24c640e58.png)

Output with these changes:

![image](https://user-images.githubusercontent.com/59961184/148904745-99a6cd16-ad3c-4dea-82d1-7efed859f1ce.png)
