### PR TITLE
fix for keyword argument `interp_kind` in curve.to_basis()

### DIFF
--- a/welly/curve.py
+++ b/welly/curve.py
@@ -759,7 +759,7 @@ class Curve(object):
                  stop=None,
                  step=None,
                  undefined=None,
-                 interp_kind=None):
+                 interp_kind='linear'):
         """
         Make a new curve in a new basis, given a basis, or a new start, step,
         and/or stop. You only need to set the parameters you want to change.
@@ -789,9 +789,6 @@ class Curve(object):
         # category data type or a string in data defaults to 'nearest'
         if self.df.dtypes[0] == 'category' or self.df.applymap(type).eq(str).any()[0]:
             interp_kind = 'nearest'
-        else:
-            # otherwise apply linear interpolation
-            interp_kind = 'linear'
 
         new_curve = copy.deepcopy(self)
 


### PR DESCRIPTION
Fix for `Curve.to_basis()` which was overwriting the keyword argument `interp_kind` to 'linear'. It now only overwrites for string and category dtype curves to 'nearest'. Default for numerical data is 'linear' but can be configured by using the argument.